### PR TITLE
add AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ sudo apt-get update
 sudo apt-get install gradio
 ```
 
+### Arch
+For Arch users, you can install the latest git version from AUR package using 
+```
+yaourt -S gradio-git
+```
+
 ## Uninstall
 If you install from source you must have the original compiled source to uninstall. `cmake` does not provide a `make uninstall` but list all the files installed on the system in `install_manifest.txt`. You can delete each file listed seperatly or run:
 ```bash


### PR DESCRIPTION
I've created an AUR package(Arch) for gradio, the package will build the latest git version. I can add a stable release too if you can create releases on Github. 
The package link : https://aur.archlinux.org/packages/gradio-git/
If you think there's something i should change on the package information, don't hesitate :)
