### PR TITLE
Added the openSUSE package

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ For Arch users, you can install the latest git version from AUR package using
 yaourt -S gradio-git
 ```
 
+### openSUSE
+A [package](https://software.opensuse.org/package/gradio) for openSUSE Tumbleweed is available.
+
 ## Uninstall
 If you install from source you must have the original compiled source to uninstall. `cmake` does not provide a `make uninstall` but list all the files installed on the system in `install_manifest.txt`. You can delete each file listed seperatly or run:
 ```bash


### PR DESCRIPTION
Packaged it and submitted https://build.opensuse.org/request/show/416016 for review. As the Gtk3 requirements are quite high, this is currently exclusively available to @openSUSE's rolling release variant Tumbleweed. If you want to get listed with a nice screenshot, we will need to submit this to openSUSE:Factory including appropriate meta data: https://people.freedesktop.org/~hughsient/appdata/