### PR TITLE
Add notifications, tray and new tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ pkg_check_modules(DEPS REQUIRED
 	gio-2.0
 	gee-0.8
 	libsoup-2.4
+	libnotify
 )
 
 set(NORMAL_CFLAGS ${DEPS_CFLAGS} ${LIBSOURCE_CFLAGS} ${GCONF_CFLAGS})
@@ -131,6 +132,7 @@ PACKAGES
 	gio-2.0
 	gee-0.8
 	libsoup-2.4
+	libnotify
 OPTIONS
 	--thread
 	--target-glib=2.38

--- a/data/ui/settings-dialog.ui
+++ b/data/ui/settings-dialog.ui
@@ -107,6 +107,30 @@
                 <property name="top_attach">2</property>
               </packing>
             </child>
+			<child>
+              <object class="GtkLabel" id="label6">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Close to tray:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="CloseToTraySwitch">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="halign">start</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>           
             <child>
               <object class="GtkSwitch" id="OnlyShowWorkingStationsSwitch">
                 <property name="visible">True</property>

--- a/schemas/de.haecker-felix.gradio.gschema.xml
+++ b/schemas/de.haecker-felix.gradio.gschema.xml
@@ -25,6 +25,11 @@
       <summary>Show stations icons or not.</summary>
     </key>
 
+    <key name="close-to-tray" type="b">
+      <default>true</default>
+      <summary>Close window to tray</summary>
+    </key>
+
     <key name="window-height" type="i">
       <default>500</default>
       <summary>Height of the window</summary>

--- a/src/AudioPlayer.vala
+++ b/src/AudioPlayer.vala
@@ -11,6 +11,7 @@ namespace Gradio{
 		public signal void tag_changed();
 
 		public string tag_title;
+		public string tag_homepage;
 		public bool tag_has_crc;
 		public string tag_audio_codec;
 		public uint tag_nominal_bitrate;
@@ -26,6 +27,22 @@ namespace Gradio{
 			set_volume(1.0);
 
 			this.notify.connect ((s, p) => stdout.printf ("Property %s changed\n", p.name));
+		}
+
+		private int EndsWithFoo(string s)
+		{
+		  int ret = 0;
+	      int si = s.length;
+		  if (s != null)
+		  {
+		    if (si >= 4 && s[si-4] == '.' && s[si-3] == 'j' && s[si-2] == 'p' && s[si-1] == 'g')
+		      ret = 1;
+		    if (si >= 4 && s[si-4] == '.' && s[si-3] == 'p' && s[si-2] == 'n' && s[si-1] == 'g')
+		      ret = 1;
+		    if (si >= 4 && s[si-4] == '.' && s[si-3] == 'b' && s[si-2] == 'm' && s[si-1] == 'p')
+		      ret = 1;
+		  }
+		  return ret;
 		}
 
 		private bool bus_callback (Gst.Bus bus, Gst.Message m) {
@@ -61,6 +78,8 @@ namespace Gradio{
 					m.parse_tag(out tag_list);
 
 					tag_list.get_string("title", out tag_title);
+					tag_list.get_string("homepage", out tag_homepage);
+					if (EndsWithFoo(tag_homepage) == 0) tag_homepage = "";
 
 					tag_list.get_boolean("has-crc", out tag_has_crc);
 

--- a/src/Widgets/MainWindow.vala
+++ b/src/Widgets/MainWindow.vala
@@ -38,6 +38,8 @@ namespace Gradio{
 			width = App.settings.get_int ("window-width");
 			height = App.settings.get_int ("window-height");
 			this.set_default_size(width, height);
+			pos_x = App.settings.get_int ("window-position-x");
+			pos_y = App.settings.get_int ("window-position-y");
 			this.move(pos_x, pos_y);
 
 			var gtk_settings = Gtk.Settings.get_default ();
@@ -91,26 +93,37 @@ namespace Gradio{
 			ContentStack.set_visible_child_name("no_connection");
 		}
 
+		public void save_geometry (){
+			this.get_position (out pos_x, out pos_y);
+			this.get_size (out width, out height);
+			App.settings.set_int("window-width", width);
+			App.settings.set_int("window-height", height);
+			App.settings.set_int("window-position-x", pos_x);
+			App.settings.set_int("window-position-y", pos_y);
+		}
+
 		private void connect_signals(){
 			App.player.radio_station_changed.connect((t,a) => {
 				player_toolbar.set_radio_station(a);
 			});
 
 			this.destroy.connect(() => {
-				App.settings.set_int("window-width", width);
-				App.settings.set_int("window-height", height);
+				save_geometry ();
 			});
+
+			this.delete_event.connect (() => {
+				save_geometry ();
+				if (App.settings.get_boolean ("close-to-tray")) {
+					this.hide_on_delete ();
+				    return true;
+				} else return false;
+		    });
 
 			this.size_allocate.connect((a) => {
 				width = a.width;
 				height = a.height;
 			});
 
-			this.drag_motion.connect((c, x, y) => {
-				App.settings.set_int("window-position-x", x);
-				App.settings.set_int("window-position-y", y);
-				return true;
-			});
 		}
 
 		[GtkCallback]

--- a/src/Widgets/PlayerToolbar.vala
+++ b/src/Widgets/PlayerToolbar.vala
@@ -38,6 +38,7 @@ namespace Gradio{
 		private MenuButton InfoMenuButton;
 
 		RadioStation station;
+		private string current_title = null;
 
 		public PlayerToolbar(){
 			this.pack_start(MediaControlBox);
@@ -50,6 +51,13 @@ namespace Gradio{
 			App.player.tag_changed.connect (() => set_information());
 
 			this.set_visible(false);
+		}
+
+		private void send_notification(string summary, string body, Gdk.Pixbuf? icon = null){
+			var noti = new Notify.Notification (summary, body, null);
+			if (icon != null)
+				noti.set_image_from_pixbuf(icon);
+			noti.show();
 		}
 
 		public void set_radio_station (RadioStation s){
@@ -91,6 +99,28 @@ namespace Gradio{
 			BitrateLabel.set_text(App.player.tag_bitrate.to_string()  + " Bit/s");
 			CodecLabel.set_text(App.player.tag_audio_codec);
 			ChannelModeLabel.set_text(App.player.tag_channel_mode);
+			if(current_title != App.player.tag_title && App.player.tag_title != null) {
+				if (App.player.tag_homepage != "") {
+					Util.get_image_from_url.begin(App.player.tag_homepage, 48, 48, (obj, res) => {
+			        	var icon = Util.get_image_from_url.end(res);
+						if(icon != null){
+						 send_notification(station.Title, App.player.tag_title, icon);
+						}else{
+						 send_notification(station.Title, App.player.tag_title, null);
+						}		
+	        		});				
+				}else{
+						Util.get_image_from_url.begin(station.Icon, 48, 48, (obj, res) => {
+			        	var icon = Util.get_image_from_url.end(res);
+						if(icon != null){
+						 send_notification(station.Title, App.player.tag_title, icon);
+						}else{
+						 send_notification(station.Title, App.player.tag_title, null);
+						}		
+						});
+				}
+			current_title = App.player.tag_title;
+			}
 		}
 
 		private void refresh_play_stop_button(){

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -10,6 +10,8 @@ namespace Gradio{
 		private Switch UseDarkDesignSwitch;
 		[GtkChild]
 		private Switch LoadPicturesSwitch;
+		[GtkChild]
+		private Switch CloseToTraySwitch;
 
 		private GLib.Settings settings;
 
@@ -47,12 +49,22 @@ namespace Gradio{
 				
 			});
 
+			CloseToTraySwitch.notify["active"].connect (() => {
+				if (CloseToTraySwitch.active) {
+					settings.set_boolean ("close-to-tray", true);
+				} else {
+					settings.set_boolean ("close-to-tray", false);
+				}
+				
+			});
+
 		}
 
 		private void load_settings(GLib.Settings settings){
 			UseDarkDesignSwitch.set_active(settings.get_boolean ("use-dark-design"));
 			LoadPicturesSwitch.set_active(settings.get_boolean ("load-pictures"));
 			OnlyShowWorkingStationsSwitch.set_active(settings.get_boolean ("only-show-working-stations"));
+			CloseToTraySwitch.set_active(settings.get_boolean ("close-to-tray"));
 		}
 
 	}


### PR DESCRIPTION
First I just want to say that I love this app, great job !

Now, I've added few things that I was missing, like tray option and closing to tray, there is a option to turn that feature off, in tray itself on right click there are options to Play / Pause and Quit. Left click will bring the main window back if it was closed to tray.
Second thing is notifications when station change to a new song.
Third thing is a new TAG , some stations provide url for the art from the front cover of the album that is playing in homepage TAG, example of that is in the attached picture, station is Radio Paradise.
If there's no art in that TAG then standard station icon will show instead.

Also, you forgot to load window positions from gsettings, so that's added as well :)

![untitled](https://cloud.githubusercontent.com/assets/11412353/17610891/d0f47d1e-6042-11e6-8705-52f4edc73e93.png)
