### PR TITLE
Save / Load Volume

### DIFF
--- a/schemas/de.haecker-felix.gradio.gschema.xml
+++ b/schemas/de.haecker-felix.gradio.gschema.xml
@@ -35,6 +35,11 @@
       <summary>Show notifications</summary>
     </key>
 
+    <key name="volume-position" type="d">
+      <default>0.99</default>
+      <summary>Volume position</summary>
+    </key>
+
     <key name="window-height" type="i">
       <default>500</default>
       <summary>Height of the window</summary>

--- a/src/AudioPlayer.vala
+++ b/src/AudioPlayer.vala
@@ -24,7 +24,7 @@ namespace Gradio{
 
 		public AudioPlayer(){
 			stream = ElementFactory.make ("playbin", "play");
-			set_volume(1.0);
+			set_volume(App.settings.get_double ("volume-position"));
 
 			this.notify.connect ((s, p) => stdout.printf ("Property %s changed\n", p.name));
 		}

--- a/src/Widgets/PlayerToolbar.vala
+++ b/src/Widgets/PlayerToolbar.vala
@@ -49,6 +49,7 @@ namespace Gradio{
 
 			App.player.state_changed.connect (() => refresh_play_stop_button());
 			App.player.tag_changed.connect (() => set_information());
+			VolumeButton.set_value(App.settings.get_double ("volume-position"));
 
 			this.set_visible(false);
 		}

--- a/src/Widgets/PlayerToolbar.vala
+++ b/src/Widgets/PlayerToolbar.vala
@@ -90,6 +90,7 @@ namespace Gradio{
 		[GtkCallback]
         	private void VolumeButton_value_changed (double value) {
 			App.player.set_volume(value);
+			App.settings.set_double("volume-position", value);
 		}
 
 		private void set_information(){


### PR DESCRIPTION
There was one thing which annoyed me and that is volume.
At least on my system default volume position in Gradio set at 1.0 was too loud for me, so I had to play some station every time in order for Volume bar to appear, then I had to lower it down.
For that reason I decided to introduce volume position saving and loading, so if you set volume to be at half for example, next time you launch Gradio it will be at half.
I found it useful, maybe you will too :)
