### PR TITLE
Fix: notification escape string

### DIFF
--- a/src/Widgets/PlayerToolbar.vala
+++ b/src/Widgets/PlayerToolbar.vala
@@ -103,9 +103,11 @@ namespace Gradio{
 
 			if (App.settings.get_boolean ("show-notifications")) {
 				if(current_title != App.player.tag_title && App.player.tag_title != null) {
-					send_notification(station.Title, App.player.tag_title);
+					string tmp = App.player.tag_title;
+					tmp = tmp.replace ("&", "&amp;");
+					send_notification(station.Title, tmp);
 
-			    		current_title = App.player.tag_title;
+					current_title = App.player.tag_title;
 		 	 	}
 			}
 		}


### PR DESCRIPTION
I've noticed empty body text in notification, which happens every time there is a & char in the string.
You can test that in terminal with : 
notify-send "test & example"

but if you send :
notify-send "test &amp; example"

it will display it correctly.

Edit : ah.. github automatically fixed the second notify-send so it doesn't show what I wanted :)
but you can see in the commit with what it has to be replaced to show it correctly