### PR TITLE
fix warning

### DIFF
--- a/src/core/gradio.vala
+++ b/src/core/gradio.vala
@@ -44,9 +44,7 @@ namespace Gradio {
 
 		private void start_new_session(){
 			player = new AudioPlayer();
-
-			Settings settings = new Settings();
-
+			
 		 	library = new Library();
 			library.read_data();
 
@@ -184,7 +182,6 @@ namespace Gradio {
 
 		// Init app
 		var app = new App ();
-
 
 		// Run app
 		app.run (args);


### PR DESCRIPTION
core/gradio.vala:48.13-48.37: warning: local variable `settings' declared but never used
			Settings settings = new Settings();