### PR TITLE
Changed behaviour of configure test for valac from warning to error if missing.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AM_INIT_AUTOMAKE([1.11 no-dist-gzip dist-xz foreign])
 AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE
 
-AM_PROG_VALAC([0.24])
+AM_PROG_VALAC([0.24],[],[AC_ERROR([no proper vala compiler found ( valac >= 0.24 )])])
 AM_PROG_CC_C_O
 
 # GResource


### PR DESCRIPTION
I've added an AC_ERROR message in the action-if-not-found argument for the valac test. This will end the configure script with an error message complaining about a missing vala compiler. It's a cleaner way as gradio compile process seems to depend on it.