### PR TITLE
fixed configuration for flatpak-builder build using meson

### DIFF
--- a/de.haeckerfelix.gradio.json
+++ b/de.haeckerfelix.gradio.json
@@ -142,7 +142,8 @@
       	{
 
             "name": "gradio",
-            "subdir": "data/packages/flatpak",
+            "buildsystem": "meson",
+            "builddir": true,
 	    "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
removed orphaned config entry and fixed the configuration for flatpak-builder