### PR TITLE
Fix station editor UI grammar

### DIFF
--- a/data/ui/station-editor.ui
+++ b/data/ui/station-editor.ui
@@ -51,7 +51,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Gradio is using a internet database. Everything what you enter here, is going to be visible for all users. Please be careful, and double check your input!</property>
+                <property name="label" translatable="yes">Gradio is using an internet database. Everything you enter here, is going to be visible for all users. Please be careful, and double check your input!</property>
                 <property name="justify">center</property>
                 <property name="wrap">True</property>
                 <property name="width_chars">50</property>

--- a/po/cs.po
+++ b/po/cs.po
@@ -152,7 +152,7 @@ msgstr "Celosvětová databáze"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -151,7 +151,7 @@ msgstr "Globale Datenbank"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -152,7 +152,7 @@ msgstr "Base de datos global"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -152,7 +152,7 @@ msgstr "Maailmanlaajuinen tietokanta"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -154,7 +154,7 @@ msgstr "Base de données générale"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/gradio.pot
+++ b/po/gradio.pot
@@ -150,7 +150,7 @@ msgstr ""
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -152,7 +152,7 @@ msgstr "Globalna baza podataka"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -152,7 +152,7 @@ msgstr "Database globale"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -152,7 +152,7 @@ msgstr "გლობალური მონაცემთა ბაზა"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -152,7 +152,7 @@ msgstr "Global database"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -153,7 +153,7 @@ msgstr "Globale database"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -153,7 +153,7 @@ msgstr "Globalna baza danych"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -155,7 +155,7 @@ msgstr "Base de dados global"
 #: data/ui/station-editor.ui:54
 #, fuzzy
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -152,7 +152,7 @@ msgstr "Base de dados global"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -153,7 +153,7 @@ msgstr ""
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -151,7 +151,7 @@ msgstr "Globálna databáza"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -152,7 +152,7 @@ msgstr "Глобална база"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -152,7 +152,7 @@ msgstr "Globalna baza"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -152,7 +152,7 @@ msgstr "Global databas"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -152,7 +152,7 @@ msgstr "Küresel veritabanı"
 
 #: data/ui/station-editor.ui:54
 msgid ""
-"Gradio is using a internet database. Everything what you enter here, is "
+"Gradio is using an internet database. Everything you enter here, is "
 "going to be visible for all users. Please be careful, and double check your "
 "input!"
 msgstr ""


### PR DESCRIPTION
Fix couple of small grammar mistakes in Station Editor UI.

"Gradio is using a internet..." ⟶ "Gradio is using an internet..."

![gradio](https://user-images.githubusercontent.com/10097295/36119616-7b9265fe-1066-11e8-95ee-56dc0546c303.png)
