### PR TITLE
typo 'by your distribution' to 'by your flatpak's distribution'

### DIFF
--- a/src/gradio-codec-installer.vala
+++ b/src/gradio-codec-installer.vala
@@ -35,8 +35,8 @@ namespace Gradio{
 				var context = new Gst.PbUtils.InstallPluginsContext();
 				Gst.PbUtils.install_plugins_async(installer_detail, context, install_callback);
 			}else{
-				warning("Installation failed. Codec installation is not supported by your distribution. Please install the missin codec by yourself.");
-				App.window.show_notification("Automatic codec installation isn't supported by your distribution.\nPlease install \""+missingcodec+"\" manually.");
+				warning("Installation failed. Codec installation is not supported by your flatpak's distribution. Please install the missin codec by yourself.");
+				App.window.show_notification("Automatic codec installation isn't supported by your flatpak's distribution.\nPlease install \""+missingcodec+"\" manually.");
 			}
 		}
 


### PR DESCRIPTION
Hi,

following the bug: https://github.com/haecker-felix/Gradio/issues/355, I've made a very very simple change from:

automatic codec installation isn't supported by your distribution

to:

automatic codec installation isn't supported by your flatpak's distribution