### PR TITLE
The Appdata files now go to /usr/share/metainfo

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -21,7 +21,7 @@ i18n.merge_file(
   po_dir: '../po/',
   type:   'xml',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 # dbus service / search provider


### PR DESCRIPTION
Tiny change. From
    `/usr/share/appdata/%{id}.appdata.xml`
to
    `/usr/share/metainfo/%{id}.appdata.xml`

https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps